### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Description
+# Description
 Cloud at Cost API
 
 Information and power operations.
@@ -640,6 +640,6 @@ Success output:
 }
 ```
 
-#TODO
+# TODO
 - reimaging
 - update metric details (currently manual on control panel login)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
